### PR TITLE
Implement shop tabs and fix player spawn location

### DIFF
--- a/platformer.py
+++ b/platformer.py
@@ -550,7 +550,9 @@ def spawn_player_on_surface(world, player: pygame.Rect, prefer_tx: int | None = 
     prefer_tx = max(0, min(WORLD_WIDTH - 1, int(prefer_tx)))
     top_y = _top_solid_pixel_y(world, prefer_tx)
     center_x_px = prefer_tx * TILE_SIZE + TILE_SIZE // 2
-    player.midbottom = (center_x_px, top_y)
+    # Nudge the player one pixel above the surface so we never spawn inside a tile.
+    # The subsequent ground-snap will drop us cleanly onto the grass.
+    player.midbottom = (center_x_px, top_y - 1)
 
 # ------------- Unstick helpers (safe after teleport) --------------------------
 def push_player_out_of_solids(world, rect: pygame.Rect) -> pygame.Rect:


### PR DESCRIPTION
## Summary
- Add tabbed shop interface with Buy/Sell screens
- Ensure player respawns on grass when leaving the shop

## Testing
- `python -m py_compile platformer.py shop_scene.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba44398eb8832c972e0e701e4d6b92