### PR TITLE
Add hostile NPCs with combat mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ python platformer.py
 
 Use the arrow keys or WASD to move. W or the up arrow jumps, A/left moves left,
 S/down moves down and D/right moves right. Left click mines tiles.
+
+Hostile NPCs spawn only in pitch-black underground areas. Click them to attack;
+tools deal more damage than bare hands and swords hit hardest. NPC health bars
+appear only after they take damage.


### PR DESCRIPTION
## Summary
- Add configurable hostile NPCs that spawn only in pitch-black areas
- Allow attacking NPCs by clicking with tools or hands and show health bars only after damage
- Update README with brief explanation of NPC combat

## Testing
- `python -m py_compile platformer.py shop_scene.py && echo "py_compile succeeded"`


------
https://chatgpt.com/codex/tasks/task_e_68bafc802958832cba11c69def192a76